### PR TITLE
Add configurable color logging

### DIFF
--- a/vol_spiral_hunter/config.ini.example
+++ b/vol_spiral_hunter/config.ini.example
@@ -50,3 +50,4 @@ monthly_expiries         = 2           ; Number of front-month serial monthly ex
 ws_queue_size            = 10000       ; Max size for internal asyncio.Queues
 ntp_max_offset_ms        = 100         ; Abort if local clock drift from NTP is greater than this
 log_level                = INFO        ; DEBUG, INFO, WARNING, ERROR, CRITICAL
+color_logging            = False       ; Enable ANSI color codes in console logs

--- a/vol_spiral_hunter/requirements.txt
+++ b/vol_spiral_hunter/requirements.txt
@@ -7,3 +7,4 @@ configparser
 ntplib
 pytest
 orjson
+colorama

--- a/vol_spiral_hunter/vol_spiral/main.py
+++ b/vol_spiral_hunter/vol_spiral/main.py
@@ -1,6 +1,10 @@
 # Vol-Spiral Hunter - Main Application Entry Point
 import asyncio
 import logging
+from logging import Handler
+from typing import List
+
+from colorama import Fore, Style, init as colorama_init
 
 from .config_loader import load_config, load_dot_env
 from .ingest import binance_ingester, deribit_ingester
@@ -8,6 +12,21 @@ from .process import metrics_calculator
 from .storage import influx_writer
 from .alert import rules_stubs
 from .utils import ntp_checker
+
+
+class ColorFormatter(logging.Formatter):
+    COLOR_MAP = {
+        logging.DEBUG: Fore.CYAN,
+        logging.INFO: Fore.GREEN,
+        logging.WARNING: Fore.YELLOW,
+        logging.ERROR: Fore.RED,
+        logging.CRITICAL: Fore.MAGENTA,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
+        color = self.COLOR_MAP.get(record.levelno, "")
+        return f"{color}{message}{Style.RESET_ALL}"
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +38,20 @@ async def main_async():
 
     # Setup logging
     log_level = getattr(logging, config.get('system', 'log_level', fallback='INFO').upper(), logging.INFO)
-    logging.basicConfig(level=log_level,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                        handlers=[logging.StreamHandler(), logging.FileHandler('vol_spiral_hunter.log')])
+    use_color = config.getboolean('system', 'color_logging', fallback=False)
+
+    console_handler = logging.StreamHandler()
+    file_handler = logging.FileHandler('vol_spiral_hunter.log')
+
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    if use_color:
+        colorama_init()
+        console_handler.setFormatter(ColorFormatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    else:
+        console_handler.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+
+    logging.basicConfig(level=log_level, handlers=[console_handler, file_handler])
 
     logger.info('Starting Vol-Spiral Hunter V0.1...')
 


### PR DESCRIPTION
## Summary
- add `color_logging` flag to config example
- include `colorama` dependency
- implement optional color formatter in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a425ec01c833283a8c05e73d36fec